### PR TITLE
Change the name of the bucket to be in par with the changes on main repo

### DIFF
--- a/src/providers/s3.ts
+++ b/src/providers/s3.ts
@@ -25,7 +25,6 @@ import { Readable, Writable } from 'stream'
 import { createWriteStream, createReadStream } from 'fs'
 import { WritableStream } from 'memory-streams'
 import makeDebug from 'debug'
-import { hostname } from 'node:os'
 const debug = makeDebug('nim:storage-s3')
 
 class S3RemoteFile implements RemoteFile {


### PR DESCRIPTION
The name of the buckets needs to be changed from having the suffix `nimbella-io` to support _Bring Your Own Domain_ feature where the client can get their custom domain names. 