### PR TITLE
Change 'web' argument to a 'type', which can be a string

### DIFF
--- a/src/providers/common.ts
+++ b/src/providers/common.ts
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2019 - present Nimbella Corp.
+ *
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+// Utilities for supporting the legacy boolean value in type 'type' field for pre-existing providers
+// (GCS and S3).
+
+import { StorageKey } from './interface'
+
+export function isWeb(type: string|boolean): boolean {
+  return type === true || type === 'web'
+}
+
+export function getBucketFromCredentials(type: string|boolean, credentials: StorageKey): string|undefined {
+  const buckets = credentials.buckets
+  if (!buckets) {
+    return undefined
+  }
+  const key = type === true ? 'web' : type === false ? 'data' : type as string
+  return buckets.get(key)
+}

--- a/src/providers/gcs.ts
+++ b/src/providers/gcs.ts
@@ -16,6 +16,7 @@ import {
   SaveOptions, SignedUrlOptions, UploadOptions, StorageKey, FileMetadata, WebsiteOptions, SettableFileMetadata
 } from './interface'
 import { Storage, Bucket, File, GetSignedUrlConfig } from '@google-cloud/storage'
+import { isWeb, getBucketFromCredentials } from './common'
 
 class GCSRemoteFile implements RemoteFile {
    private file: File
@@ -119,10 +120,11 @@ const provider: StorageProvider = {
     const { client_email, private_key, project_id } = original
     return { credentials: { client_email, private_key }, project_id, provider: '@nimbella/storage-gcs' }
   },
-  getClient: (namespace: string, apiHost: string, web: boolean, credentials: Record<string, any>) => {
+  getClient: (namespace: string, apiHost: string, type: boolean|string, credentials: Record<string, any>) => {
     Object.assign(credentials, { projectId: credentials.project_id })
     const storage: Storage = new Storage(credentials)
-    const bucketName = computeBucketStorageName(apiHost, namespace, web)
+    const web = isWeb(type)
+    const bucketName = getBucketFromCredentials(type, credentials) || computeBucketStorageName(apiHost, namespace, web)
     const bucket = storage.bucket(bucketName)
 
     if (web) {

--- a/src/providers/interface.ts
+++ b/src/providers/interface.ts
@@ -15,6 +15,7 @@
 // semantics.  The rest is at the convenience of the provider.
 export type StorageKey = {
         provider?: string // Assume '@nimbella/storage-gcs' if omitted
+        buckets?: Map<string, string> // Assume empty if omitted
     } & {
         [prop: string]: any
     }
@@ -119,7 +120,7 @@ export interface StorageClient {
 // The top-level signature of a storage provider
 export interface StorageProvider {
     // Provide the appropriate client handle for accessing a type file store (web or data) in a particular namespace
-    getClient: (namespace: string, apiHost: string, web: boolean, credentials: StorageKey) => StorageClient
+    getClient: (namespace: string, apiHost: string, type: boolean|string, credentials: StorageKey) => StorageClient
     // Convert an object containing credentials as stored in couchdb into the proper form for the credential store
     // Except for GCS, which is grandfathered as the default, the result must include a 'provider' field denoting
     // a valid npm-installable package

--- a/src/providers/s3.ts
+++ b/src/providers/s3.ts
@@ -24,6 +24,7 @@ import { getSignedUrl } from '@aws-sdk/s3-request-presigner'
 import { Readable, Writable } from 'stream'
 import { createWriteStream, createReadStream } from 'fs'
 import { WritableStream } from 'memory-streams'
+import { isWeb, getBucketFromCredentials } from './common'
 import makeDebug from 'debug'
 const debug = makeDebug('nim:storage-s3')
 
@@ -280,11 +281,12 @@ const provider: StorageProvider = {
     debug('preparing credentials: %O', original)
     return original as StorageKey
   },
-  getClient: (namespace: string, apiHost: string, web: boolean, credentials: Record<string, any>) => {
+  getClient: (namespace: string, apiHost: string, type: boolean|string, credentials: Record<string, any>) => {
     debug('making S3Client with credentials %O', credentials)
     const s3 = new S3Client(credentials)
     debug('have client: %O', s3)
-    const bucketName = computeBucketStorageName(apiHost, namespace, web)
+    const web = isWeb(type)
+    const bucketName = getBucketFromCredentials(type, credentials) || computeBucketStorageName(apiHost, namespace, web)
     if (web) {
       const url: string = credentials.weburl || computeBucketUrl(credentials.endpoint, bucketName)
       return new NimS3Client(s3, bucketName, url)


### PR DESCRIPTION
This supports the possibility that a namespace can have multiple
Specialized buckets in addition to or instead of the standard 'web' and
'Data' pair.